### PR TITLE
Potential fix for code scanning alert no. 3: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/main/java/org/mesutormanli/visualnovel/engine/util/RelativeLayout.java
+++ b/src/main/java/org/mesutormanli/visualnovel/engine/util/RelativeLayout.java
@@ -507,7 +507,7 @@ public class RelativeLayout implements LayoutManager2, java.io.Serializable {
                 Dimension d = component.getPreferredSize();
                 spaceAvailable -= d.height;
             } else {
-                relativeTotal += constraint.doubleValue();
+                relativeTotal += constraint.floatValue();
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/hyperpostulate/visual-novel-engine/security/code-scanning/3](https://github.com/hyperpostulate/visual-novel-engine/security/code-scanning/3)

In general, this kind of issue is fixed by ensuring both sides of the compound assignment have compatible types, so no implicit narrowing cast is required. Either the destination variable is widened (e.g., `float` → `double`), or the right-hand side expression is computed in the narrower type (e.g., `double` → `float`), typically by using the appropriate accessor (`floatValue()`) or an explicit cast.

For this specific case, the clearest, behaviour-preserving fix is to keep `relativeTotal` as a `float` (since constraints are `Float`s), and avoid using `doubleValue()`. Instead, use `constraint.floatValue()` so that both operands of `+=` are `float`. That avoids any implicit `double`→`float` narrowing, and there is no functional change: a `Float`’s `floatValue()` and `doubleValue()` hold the same underlying precision, just represented in a wider type for `doubleValue()`.

Concretely, in `src/main/java/org/mesutormanli/visualnovel/engine/util/RelativeLayout.java`, in the `layoutContainerVertically` method, change line 510 from `relativeTotal += constraint.doubleValue();` to `relativeTotal += constraint.floatValue();`. No imports or additional methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
