### PR TITLE
Potential fix for code scanning alert no. 2: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/main/java/org/mesutormanli/visualnovel/engine/util/RelativeLayout.java
+++ b/src/main/java/org/mesutormanli/visualnovel/engine/util/RelativeLayout.java
@@ -415,7 +415,7 @@ public class RelativeLayout implements LayoutManager2, java.io.Serializable {
                 Dimension d = component.getPreferredSize();
                 spaceAvailable -= d.width;
             } else {
-                relativeTotal += constraint.doubleValue();
+                relativeTotal += constraint.floatValue();
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/hyperpostulate/visual-novel-engine/security/code-scanning/2](https://github.com/hyperpostulate/visual-novel-engine/security/code-scanning/2)

In general, to fix implicit narrowing in compound assignments you ensure that both operands have compatible types, either by widening the destination or by making the right-hand side expression match the destination type (without relying on implicit narrowing).

In this specific case, the constraints are stored as `Float`, and the accumulator `relativeTotal` is also a `float`. The problematic line uses `constraint.doubleValue()`, which promotes the value to `double` and then implicitly narrows back to `float` in the `+=` operation. The safest, behavior-preserving fix is to use the `float` representation directly: call `constraint.floatValue()` instead of `doubleValue()`. That way, the addition is performed in `float` without an implicit narrowing cast, and the effective precision is unchanged because the source data is already a `Float`.

Concretely:
- In `src/main/java/org/mesutormanli/visualnovel/engine/util/RelativeLayout.java`, inside `layoutContainerHorizontally`, change line 418 from `relativeTotal += constraint.doubleValue();` to `relativeTotal += constraint.floatValue();`.
- No imports, method additions, or type changes are needed; we only change the accessor used on `Float`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
