### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/hyperpostulate/visual-novel-engine/security/code-scanning/4](https://github.com/hyperpostulate/visual-novel-engine/security/code-scanning/4)

In general, the problem is fixed by explicitly specifying a `permissions:` block either at the workflow root (applies to all jobs) or per job (applies to that job only). For a simple Maven CI build that just checks out the repository and builds it, the GITHUB_TOKEN only needs read access to the repository contents.

The best minimal fix here is to add a `permissions:` block at the workflow root, just after the `on:` section and before `jobs:`. This will apply to all jobs (currently only `build`) and restrict the token to read-only repository contents. No change is needed to the existing steps because `actions/checkout` works with `contents: read`. Concretely, in `.github/workflows/maven.yml`, between line 16 (`branches: [ "master" ]` under `pull_request`) and line 17 (`jobs:`), insert:

```yaml
permissions:
  contents: read
```

No imports, methods, or other definitions are required; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
